### PR TITLE
Add ability to hide taskprogress on success

### DIFF
--- a/bubbles/taskprogress/__snapshots__/model_test.snap
+++ b/bubbles/taskprogress/__snapshots__/model_test.snap
@@ -34,3 +34,7 @@
 [TestModel_View/respond_to_title_width - 1]
  ✔ Did work              [done!]                                                           at home
 ---
+
+[TestModel_View/successfully_can_hide_the_entire_line - 1]
+
+---

--- a/bubbles/taskprogress/model.go
+++ b/bubbles/taskprogress/model.go
@@ -44,6 +44,7 @@ type Model struct {
 	UpdateDuration        time.Duration
 	HideProgressOnSuccess bool
 	HideStageOnSuccess    bool
+	HideOnSuccess         bool
 
 	TitleStyle lipgloss.Style
 	// TitlePendingStyle lipgloss.Style
@@ -139,7 +140,7 @@ func (m Model) Init() tea.Cmd {
 				// will ignore messages that don't contain ID by default.
 				ID: m.id,
 
-				sequence: m.sequence,
+				Sequence: m.sequence,
 			}
 		},
 		m.Spinner.Tick,
@@ -158,6 +159,11 @@ func (m Model) Init() tea.Cmd {
 // ID returns the spinner's unique ID.
 func (m Model) ID() int {
 	return m.id
+}
+
+// ID returns the spinner's unique ID.
+func (m Model) Sequence() int {
+	return m.sequence
 }
 
 // Update is the Tea update function.
@@ -230,6 +236,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders the model's view.
 func (m Model) View() string {
+	if m.completed && m.HideOnSuccess {
+		return ""
+	}
 	beforeProgress := " "
 	if m.completed {
 		if m.err != nil {
@@ -283,7 +292,7 @@ func (m Model) queueNextTick(id, sequence int) tea.Cmd {
 		return TickMsg{
 			Time:     t,
 			ID:       id,
-			sequence: sequence,
+			Sequence: sequence,
 		}
 	})
 }
@@ -298,7 +307,7 @@ func (m *Model) handleTick(msg TickMsg) tea.Cmd {
 	// If a sequence is set, and it's not the one we expect, reject the message.
 	// This prevents the spinner from receiving too many messages and
 	// thus spinning too fast.
-	if msg.sequence > 0 && msg.sequence != m.sequence {
+	if msg.Sequence > 0 && msg.Sequence != m.sequence {
 		return nil
 	}
 

--- a/bubbles/taskprogress/model_test.go
+++ b/bubbles/taskprogress/model_test.go
@@ -125,6 +125,17 @@ func TestModel_View(t *testing.T) {
 			},
 		},
 		{
+			name: "successfully can hide the entire line",
+			taskGen: func(tb testing.TB) Model {
+				prog, stage, tsk := subject(t)
+				tsk.HideOnSuccess = true
+				// note: we set progress to have a total size to ensure it is hidden
+				prog.N, prog.Total = 100, 100
+				stage.Current = "done!"
+				return tsk
+			},
+		},
+		{
 			name: "no context",
 			taskGen: func(tb testing.TB) Model {
 				_, _, tsk := subject(t)
@@ -158,7 +169,7 @@ func TestModel_View(t *testing.T) {
 			require.True(t, ok)
 			got := testutil.RunModel(t, tsk, tt.iterations, TickMsg{
 				Time:     time.Now(),
-				sequence: tsk.sequence,
+				Sequence: tsk.sequence,
 				ID:       tsk.id,
 			})
 			t.Log(got)

--- a/bubbles/taskprogress/tick.go
+++ b/bubbles/taskprogress/tick.go
@@ -7,6 +7,6 @@ import (
 // TickMsg indicates that the timer has ticked and we should render a frame.
 type TickMsg struct {
 	Time     time.Time
-	sequence int
+	Sequence int
 	ID       int
 }


### PR DESCRIPTION
Adds the ability to hide an entire line when a `taskprogress.Model` finishes successfully. Additionally exposes all elements on a `taskprogress.TickMsg` as well as the current sequence number on a `taskprogress.Model` to aid in downstream testing.