### PR TITLE
add oss community board auto-add workflow

### DIFF
--- a/.github/workflows/oss-project-board-add.yaml
+++ b/.github/workflows/oss-project-board-add.yaml
@@ -1,0 +1,22 @@
+name: Add to OSS board
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+      - labeled
+
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - reopened
+
+jobs:
+
+  run:
+    uses: "anchore/workflows/.github/workflows/oss-project-board-add.yaml@main"
+    secrets:
+      token: ${{ secrets.OSS_PROJECT_GH_TOKEN }}

--- a/.github/workflows/oss-project-board-add.yaml
+++ b/.github/workflows/oss-project-board-add.yaml
@@ -8,12 +8,6 @@ on:
       - transferred
       - labeled
 
-  pull_request:
-    types:
-      - labeled
-      - opened
-      - reopened
-
 jobs:
 
   run:


### PR DESCRIPTION
Allows for automatically adding issues to the [OSS community board](https://github.com/orgs/anchore/projects/22)