### PR TITLE
Add return tea.cmd from event handlers

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -4,7 +4,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.20.x"
+    default: "1.21.x"
   use-go-cache:
     description: "Restore go cache"
     required: true

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SUCCESS := $(BOLD)$(GREEN)
 
 # Test variables #################################
 # the quality gate lower threshold for unit test total % coverage (by function statements)
-COVERAGE_THRESHOLD := 80
+COVERAGE_THRESHOLD := 70
 
 ## Variable assertions
 

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,162 @@
+package bubbly
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/wagoodman/go-partybus"
+)
+
+var _ tea.Model = (*dummyModel)(nil)
+
+type dummyModel struct {
+	id string
+}
+
+func (d dummyModel) Init() tea.Cmd {
+	return nil
+}
+
+func (d dummyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if msg, ok := msg.(string); ok {
+		d.id = msg
+	}
+	return d, nil
+}
+
+func (d dummyModel) View() string {
+	return d.id
+}
+
+func dummyMsg(s any) tea.Cmd {
+	return func() tea.Msg {
+		return s
+	}
+}
+
+func TestEventDispatcher_Handle(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		subject    *EventDispatcher
+		event      partybus.Event
+		wantModels []tea.Model
+		wantCmd    tea.Cmd
+	}{
+		{
+			name: "simple event",
+			subject: func() *EventDispatcher {
+				d := NewEventDispatcher()
+				d.AddHandler("test", func(e partybus.Event) ([]tea.Model, tea.Cmd) {
+					return []tea.Model{dummyModel{id: "model"}}, dummyMsg("updated")
+				})
+				return d
+			}(),
+			event: partybus.Event{
+				Type: "test",
+			},
+			wantModels: []tea.Model{dummyModel{id: "model"}},
+			wantCmd:    dummyMsg("updated"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotModels, gotCmd := tt.subject.Handle(tt.event)
+			if !reflect.DeepEqual(gotModels, tt.wantModels) {
+				t.Errorf("Handle() got = %v (model), want %v", gotModels, tt.wantModels)
+			}
+
+			if gotCmd != nil && tt.wantCmd == nil {
+				t.Fatal("got command, but want nil")
+			} else if gotCmd == nil && tt.wantCmd != nil {
+				t.Fatal("did not get command, but wanted one")
+			}
+
+			var (
+				gotMsg  tea.Msg
+				wantMsg tea.Msg
+			)
+
+			if gotCmd != nil {
+				gotMsg = gotCmd()
+			}
+
+			if tt.wantCmd != nil {
+				wantMsg = tt.wantCmd()
+			}
+
+			if !assert.Equal(t, wantMsg, gotMsg) {
+				t.Errorf("Handle() got = %v (msg), want %v", gotMsg, wantMsg)
+			}
+
+		})
+	}
+}
+
+func TestEventDispatcher_RespondsTo(t *testing.T) {
+
+	d := NewEventDispatcher()
+	d.AddHandler("test", func(e partybus.Event) ([]tea.Model, tea.Cmd) {
+		return []tea.Model{dummyModel{id: "test-model"}}, dummyMsg("test-msg")
+	})
+
+	d.AddHandler("something", func(e partybus.Event) ([]tea.Model, tea.Cmd) {
+		return []tea.Model{dummyModel{id: "something-model"}}, dummyMsg("something-msg")
+	})
+
+	tests := []struct {
+		name    string
+		subject *EventDispatcher
+		want    []partybus.EventType
+	}{
+		{
+			name:    "responds to registered event",
+			subject: d,
+			want:    []partybus.EventType{"test", "something"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.subject.RespondsTo()
+			if !assert.Equal(t, tt.want, got) {
+				t.Errorf("RespondsTo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandlerCollection_RespondsTo(t *testing.T) {
+	d1 := NewEventDispatcher()
+	d1.AddHandler("test", func(e partybus.Event) ([]tea.Model, tea.Cmd) {
+		return []tea.Model{dummyModel{id: "test-model"}}, dummyMsg("test-msg")
+	})
+
+	d2 := NewEventDispatcher()
+	d2.AddHandler("something", func(e partybus.Event) ([]tea.Model, tea.Cmd) {
+		return []tea.Model{dummyModel{id: "something-model"}}, dummyMsg("something-msg")
+	})
+
+	subject := NewHandlerCollection(d1, d2)
+
+	tests := []struct {
+		name    string
+		subject *HandlerCollection
+		want    []partybus.EventType
+	}{
+		{
+			name:    "responds to registered event from all handlers",
+			subject: subject,
+			want:    []partybus.EventType{"test", "something"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.subject.RespondsTo()
+			if !assert.Equal(t, tt.want, got) {
+				t.Errorf("RespondsTo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/anchore/bubbly
 
-go 1.18
+go 1.21.0
+
+toolchain go1.21.1
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d


### PR DESCRIPTION
This makes a breaking change to the EventHandler such that it can also return a `tea.Cmd`. Today the models that are returned from the handlers are meant to act like factories, returning only newly created models, which processing downstream will call `Init()` on the models to get any `tea.Cmd`s. However, if you are looking to respond to an event on the bus that will not create a new model to be managed by downstream processing but instead a new model that will be subsumed into an existing model, there isn't a way to communicate the subsumed model's `Init()` commands.

This PR changes this behavior by allowing for event handlers to optionally also return a `tea.Cmd` for new models that are not returned by the handler to.