### PR TITLE
chore: disable auto-merge on non-dependabot push

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -32,10 +32,8 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
         if: >
-          ${{ 
-              ( steps.pr_author.human_pushed != "true" ) &&
-              ( steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' ) 
-          }}
+            ( steps.pr_author.human_pushed != 'true' ) &&
+            ( steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' )
         run: gh pr merge --auto --squash "$PR_URL" && gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -39,7 +39,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Disable auto-merge if human modified PR
-        if: steps.pr_author.human_pushed == "true"
+        if: steps.pr_author.human_pushed == 'true'
         run: |
           echo "disabling auto-merge due to non-dependabot push"
           gh pr merge --disable-auto "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -17,9 +17,35 @@ jobs:
         uses: dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # v1.6.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Check whether anyone besides dependabot has pushed
+        id: pr_author
+        run: |
+          EXTRA_AUTHORS=$(gh pr view "$PR_URL" --json commits --jq '.commits[] | .authors[] | .login' | sort | uniq | grep -v dependabot)
+          if [ -n "$EXTRA_AUTHORS" ]; then
+            echo "PR has authors in addition to dependabot: $EXTRA_AUTHORS"
+            echo "human_pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "human_pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: >
+          ${{ 
+              ( steps.pr_author.human_pushed != "true" ) &&
+              ( steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' ) 
+          }}
         run: gh pr merge --auto --squash "$PR_URL" && gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Disable auto-merge if human modified PR
+        if: steps.pr_author.human_pushed == "true"
+        run: |
+          echo "disabling auto-merge due to non-dependabot push"
+          gh pr merge --disable-auto "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+


### PR DESCRIPTION
When a human starts interacting with a dependabot PR to try to unblock it, having the auto-merge still enabled is surprising. Therefore, if a user besides dependabot pushes to the branch, disable auto-merge.