### PR TITLE
chore: fix dependabot author check

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Check whether anyone besides dependabot has pushed
         id: pr_author
         run: |
-          EXTRA_AUTHORS=$(gh pr view "$PR_URL" --json commits --jq '.commits[] | .authors[] | .login' | sort | uniq | grep -v dependabot)
+          EXTRA_AUTHORS=$(gh pr view "$PR_URL" --json commits --jq '.commits[] | .authors[] | .login' | sort | uniq | grep -v dependabot || echo -n '')
           if [ -n "$EXTRA_AUTHORS" ]; then
             echo "PR has authors in addition to dependabot: $EXTRA_AUTHORS"
             echo "human_pushed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Apparently GH actions scripts run with set -e, so the search miss on this grep was causing the entire action to fail.