### PR TITLE
fix: use pointer to frame as receiver

### DIFF
--- a/bubbles/frame/frame.go
+++ b/bubbles/frame/frame.go
@@ -68,7 +68,7 @@ func (f Frame) Init() tea.Cmd {
 	return nil
 }
 
-func (f Frame) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (f *Frame) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if msg, ok := msg.(tea.WindowSizeMsg); ok {
 		f.windowSize = msg
 	}

--- a/bubbles/frame/frame_test.go
+++ b/bubbles/frame/frame_test.go
@@ -60,7 +60,7 @@ func TestFrame_Update_PruneTerminalElement(t *testing.T) {
 	frame.AppendModel(model)
 
 	m, _ := frame.Update(nil)
-	actual := m.(Frame)
+	actual := m.(*Frame)
 
 	assert.Empty(t, actual.models)
 }
@@ -72,7 +72,7 @@ func TestFrame_Update_HideVisibleElement(t *testing.T) {
 	frame.AppendModel(model)
 
 	m, _ := frame.Update(nil)
-	actual := m.(Frame)
+	actual := m.(*Frame)
 
 	require.NotEmpty(t, actual.models)
 	assert.True(t, actual.models[0].hidden)
@@ -85,7 +85,7 @@ func TestFrame_Update_ImprintImprintableElement(t *testing.T) {
 	frame.AppendModel(model)
 
 	m, cmds := frame.Update(nil)
-	actual := m.(Frame)
+	actual := m.(*Frame)
 
 	assert.True(t, actual.models[0].expired)
 	assert.NotNil(t, cmds)
@@ -98,7 +98,7 @@ func TestFrame_Update_UpdateElement(t *testing.T) {
 	frame.AppendModel(model)
 
 	m, cmds := frame.Update(nil)
-	actual := m.(Frame)
+	actual := m.(*Frame)
 
 	assert.Nil(t, cmds)
 	assert.True(t, actual.models[0].model.(mockModel).updateCalled)


### PR DESCRIPTION
Otherwise, bubblytea will panic interacting with this library.

Examples from anchore/grype:

## Before

```
$ go run ./cmd/grype alpine:latest
Caught panic:

interface conversion: tea.Model is frame.Frame, not *frame.Frame

Restoring terminal...

goroutine 54 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0x14000cb23c0, {0x106d2e4a0, 0x14000d84930})
        /Users/willmurphy/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.6/tea.go:810 +0xa0
github.com/charmbracelet/bubbletea.(*Program).Run.func2()
        /Users/willmurphy/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.6/tea.go:601 +0xdc
panic({0x106d2e4a0?, 0x14000d84930?})
        /usr/local/go/src/runtime/panic.go:792 +0x124
github.com/anchore/grype/cmd/grype/internal/ui.(*UI).Update(0x140006921e0, {0x106f82e80, 0x14000d8e380})
        /Users/willmurphy/work/fix-bubbly/grype/cmd/grype/internal/ui/ui.go:170 +0x8a8
github.com/charmbracelet/bubbletea.(*Program).eventLoop(0x14000cb23c0, {0x1071d1880?, 0x140006921e0?}, 0x140008100e0)
        /Users/willmurphy/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.6/tea.go:525 +0x658
github.com/charmbracelet/bubbletea.(*Program).Run(0x14000cb23c0)
        /Users/willmurphy/go/pkg/mod/github.com/charmbracelet/bubbletea@v1.3.6/tea.go:679 +0x958
github.com/anchore/grype/cmd/grype/internal/ui.(*UI).Setup.func1()
        /Users/willmurphy/work/fix-bubbly/grype/cmd/grype/internal/ui/ui.go:59 +0x50
created by github.com/anchore/grype/cmd/grype/internal/ui.(*UI).Setup in goroutine 1
        /Users/willmurphy/work/fix-bubbly/grype/cmd/grype/internal/ui/ui.go:57 +0x1d4
```

## After

```
$ go run ./cmd/grype alpine:latest
NAME           INSTALLED   FIXED IN  TYPE  VULNERABILITY   SEVERITY  EPSS          RISK
libcrypto3     3.5.0-r0    3.5.1-r0  apk   CVE-2025-4575   Medium    < 0.1% (6th)  < 0.1
libssl3        3.5.0-r0    3.5.1-r0  apk   CVE-2025-4575   Medium    < 0.1% (6th)  < 0.1
busybox        1.37.0-r18            apk   CVE-2025-46394  Low       < 0.1% (2nd)  < 0.1
busybox-binsh  1.37.0-r18            apk   CVE-2025-46394  Low       < 0.1% (2nd)  < 0.1
ssl_client     1.37.0-r18            apk   CVE-2025-46394  Low       < 0.1% (2nd)  < 0.1
busybox        1.37.0-r18            apk   CVE-2024-58251  Low       < 0.1% (2nd)  < 0.1
busybox-binsh  1.37.0-r18            apk   CVE-2024-58251  Low       < 0.1% (2nd)  < 0.1
ssl_client     1.37.0-r18            apk   CVE-2024-58251  Low       < 0.1% (2nd)  < 0.1
```

