### PR TITLE
chore(deps): restore Go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/bubbly
 
-go 1.26.2
+go 1.22
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d


### PR DESCRIPTION
Restores the go directive in go.mod to 1.22 (pre-#159). Bumped in #159 (merge 0d60f4fa50f3b17bf7b902b8435f2d621b92701a).