### PR TITLE
Minimal workflow permissions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -13,6 +13,8 @@ on:
   schedule:
     - cron: '38 11 * * 3'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})


### PR DESCRIPTION
explicitly sets permissions to empty for the workflow.